### PR TITLE
Fix double timeout? tested on local

### DIFF
--- a/src/pdm4ar/exercises/ex07/ex07.py
+++ b/src/pdm4ar/exercises/ex07/ex07.py
@@ -9,6 +9,8 @@ from pdm4ar.exercises_def.ex07.structures import (
     SolutionVoyage,
 )
 
+import time
+
 
 def solve_optimization(problem: ProblemVoyage) -> SolutionVoyage:
     """
@@ -36,5 +38,7 @@ def solve_optimization(problem: ProblemVoyage) -> SolutionVoyage:
     else:
         feasibility = Feasibility.unfeasible
         voyage_plan = None
+
+    # time.sleep(1000)
 
     return SolutionVoyage(feasibility, voyage_plan)

--- a/src/pdm4ar/exercises/ex07/ex07.py
+++ b/src/pdm4ar/exercises/ex07/ex07.py
@@ -9,8 +9,6 @@ from pdm4ar.exercises_def.ex07.structures import (
     SolutionVoyage,
 )
 
-import time
-
 
 def solve_optimization(problem: ProblemVoyage) -> SolutionVoyage:
     """
@@ -38,7 +36,5 @@ def solve_optimization(problem: ProblemVoyage) -> SolutionVoyage:
     else:
         feasibility = Feasibility.unfeasible
         voyage_plan = None
-
-    # time.sleep(1000)
 
     return SolutionVoyage(feasibility, voyage_plan)

--- a/src/pdm4ar/exercises_def/structures_time.py
+++ b/src/pdm4ar/exercises_def/structures_time.py
@@ -43,14 +43,14 @@ def run_with_timer(func, max_execution_time) -> Union[Any, Exception]:
         p.start()
         if recv_end.poll(max_execution_time):
             result = recv_end.recv()
+            p.join(max_execution_time)
+            if p.is_alive():
+                p.terminate()
+                p.join()
+                result = TestCaseTimeoutException("Exceeded test case timeout.")
         else:
             result = TestCaseTimeoutException("Exceeded test case timeout.")
-        p.join(max_execution_time)
-        if p.is_alive():
-            p.terminate()
-            p.join()
-            result = TestCaseTimeoutException("Exceeded test case timeout.")
-
+        
         return result
 
     return wrapper

--- a/src/pdm4ar/exercises_def/structures_time.py
+++ b/src/pdm4ar/exercises_def/structures_time.py
@@ -43,14 +43,14 @@ def run_with_timer(func, max_execution_time) -> Union[Any, Exception]:
         p.start()
         if recv_end.poll(max_execution_time):
             result = recv_end.recv()
-            p.join(max_execution_time)
-            if p.is_alive():
-                p.terminate()
-                p.join()
-                result = TestCaseTimeoutException("Exceeded test case timeout.")
         else:
             result = TestCaseTimeoutException("Exceeded test case timeout.")
-        
+        p.join(0.05)
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            result = TestCaseTimeoutException("Exceeded test case timeout.")
+
         return result
 
     return wrapper


### PR DESCRIPTION
The current timeout is practically doubled, so if timeout=10 seconds, the test case has an actual timeout of 20 seconds, but the solution has to be provided anyway in the first 10 seconds: the extra 10 seconds are useless, since the result of the function will not be checked.

Changed p.join(max_timeout) to p.join(0.05).