### PR TITLE
Fix typos and update broken links

### DIFF
--- a/docs/02-graphsearch.md
+++ b/docs/02-graphsearch.md
@@ -2,7 +2,7 @@
 
 <table>
   <tr>
-    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-hello-world.html" target="_top">Hello-world</a></td>
+    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-helloworld.html" target="_top">Hello-world</a></td>
   </tr>
 </table>
 
@@ -127,7 +127,7 @@ For reference, the TA’s solution achieves the following average solving times 
 | BreadthFirst        | 0.000239        |
 | IterativeDeepening  | 0.000867        |
 
-Use these numbers as a guideline to understand the order of magnitude of expected performance for a descently optimized solution.
+Use these numbers as a guideline to understand the order of magnitude of expected performance for a decently optimized solution.
 
 Keep in mind:
 - These times are for reference only, your implementation does not need to match them exactly.

--- a/docs/03-informedgraphsearch.md
+++ b/docs/03-informedgraphsearch.md
@@ -2,7 +2,7 @@
 
 <table>
   <tr>
-    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-hello-world.html" target="_top">Hello-world</a></td>
+    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-helloworld.html" target="_top">Hello-world</a></td>
   </tr>
 </table>
 
@@ -157,7 +157,7 @@ For reference, the TA’s solution achieves the following efficiency and solving
 | Heuristic efficiency|     0.6112  |
 | Solve time [s]      |     0.0102  |
 
-Use these numbers as a guideline to understand the order of magnitude of expected performance for a descently optimized solution.
+Use these numbers as a guideline to understand the order of magnitude of expected performance for a decently optimized solution.
 
 
 ### Useful remarks from last year Q&A

--- a/docs/05-dubinspath.md
+++ b/docs/05-dubinspath.md
@@ -2,7 +2,7 @@
 
 <table>
   <tr>
-    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-hello-world.html" target="_top">Hello-world</a></td>
+    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-helloworld.html" target="_top">Hello-world</a></td>
   </tr>
 </table>
 

--- a/docs/06-collisionchecking.md
+++ b/docs/06-collisionchecking.md
@@ -2,7 +2,7 @@
 
 <table>
   <tr>
-    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-hello-world.html" target="_top">Hello-world</a></td>
+    <th><i>Prerequisites:</i></th><td><a href="./00-preliminaries.html" target="_top">Preliminaries</a></td><td><a href="./01-helloworld.html" target="_top">Hello-world</a></td>
   </tr>
 </table>
 

--- a/docs/09-pdm4arocket_explorer.md
+++ b/docs/09-pdm4arocket_explorer.md
@@ -136,7 +136,7 @@ The various data structures needed for the development of the exercise can be in
 
 We developed the exercises based on the following
 paper ([Convex Optimisation for Trajectory Generation](https://arxiv.org/pdf/2106.09125.pdf)) on SCvx, the planning
-method used in 2021 by spaceX to land their rocket on a moving platform in the middle of the ocean. We recommend to use
+method used in 2021 by SpaceX to land their rocket on a moving platform in the middle of the ocean. We recommend to use
 such a method to solve the problem but you are free to come up with your own solution. We made available some basic
 skeleton structure to implement the SCvx pipeline in the **planner.py**. The **discretization.py** file provides an
 implementation of the ZeroOrderHold and FirstOrderHold that is used in the convexification step of the SCvx pipeline to

--- a/docs/12-highway_driving.md
+++ b/docs/12-highway_driving.md
@@ -3,7 +3,7 @@
 This exercise is the final graded exercise issued for the Fall semester of 2024.
 
 ## Problem description
-Your task is to implement a planning (and control) stack for an autonomous vehicle, so that it can navigate safely and efficiently on highways with mixed traffic(i.e. you are surrounded by human drivers).
+Your task is to implement a planning (and control) stack for an autonomous vehicle, so that it can navigate safely and efficiently on highways with mixed traffic (i.e. you are surrounded by human drivers).
 
 Specifically, given a desired lane, your planning stack needs to perform the lane changing maneuver without colliding with other road users. 
 Note that, just like driving in real life, you can observe the current states of other vehicles, but you do **NOT** know the exact action or policy others plan to take. Nonetheless, it is safe to assume that others obey the social conventions just as you do. For example, they will not intentionally crash on you and will try their best to avoid collisions.


### PR DESCRIPTION
This PR fixes some typos in text and links:

Links to 'hello-world.html' -> 'helloworld.html'
'descent' -> 'decent' (chapters 2 and 3)
'spaceX' -> 'SpaceX' (chapter 9)
'...mixed traffic(i.e. you...' -> '...mixed traffic (i.e. you...' (chapter 11)
